### PR TITLE
File downloading

### DIFF
--- a/lib/blueprints/localfilestorage-blueprint/blueprint.json
+++ b/lib/blueprints/localfilestorage-blueprint/blueprint.json
@@ -1,0 +1,16 @@
+{
+  "namespace": "tymly",
+  "name": "localfilestorage-blueprint",
+  "version": "1.0.0",
+  "label": "",
+  "organisation": "West Midlands Fire Service",
+  "description": "Support for local file storage",
+  "categories": [],
+  "meta": {
+    "generatedOn": "20/06/20, 09:36:23",
+    "generatedWith":"@wmfs/tymly-scaffold 0.0.0-semantically-released",
+    "domains": [
+      "general"
+    ]
+  }
+}

--- a/lib/blueprints/localfilestorage-blueprint/index.js
+++ b/lib/blueprints/localfilestorage-blueprint/index.js
@@ -1,0 +1,1 @@
+// placeholder, here simply so we can resolve the module

--- a/lib/blueprints/localfilestorage-blueprint/state-machines/download-from-local-file-storage.json
+++ b/lib/blueprints/localfilestorage-blueprint/state-machines/download-from-local-file-storage.json
@@ -22,7 +22,7 @@
         "filePath.$": "$.localFilePath",
         "deleteAfterDownload": true
       },
-      "ResultPath": "$.downloadUrl",
+      "ResultPath": "$.downloadPath",
       "Next": "Immediate"
     },
     "Immediate": {

--- a/lib/blueprints/localfilestorage-blueprint/state-machines/download-from-local-file-storage.json
+++ b/lib/blueprints/localfilestorage-blueprint/state-machines/download-from-local-file-storage.json
@@ -1,0 +1,20 @@
+{
+  "Comment": "Download a file from local file storage",
+  "name": "Download File",
+  "version": "1.0",
+  "categories": [],
+  "StartAt": "CopyLocally",
+  "States": {
+    "CopyLocally": {
+      "Type": "Succeed"
+    }
+  },
+  "restrictions": [
+    {
+      "roleId": "$authenticated",
+      "allows": [
+        "*"
+      ]
+    }
+  ]
+}

--- a/lib/blueprints/localfilestorage-blueprint/state-machines/download-from-local-file-storage.json
+++ b/lib/blueprints/localfilestorage-blueprint/state-machines/download-from-local-file-storage.json
@@ -6,7 +6,31 @@
   "StartAt": "CopyLocally",
   "States": {
     "CopyLocally": {
-      "Type": "Succeed"
+      "Type": "Task",
+      "Resource": "module:copyFileToLocalFolder",
+      "Parameters": {
+        "localFolderPath.$": "$.localFolderPath",
+        "remoteFilePath.$": "$.remoteFilePath"
+      },
+      "ResultPath": "$.localFilePath",
+      "Next": "DownloadFile"
+    },
+    "DownloadFile": {
+      "Type": "Task",
+      "Resource": "module:fileDownloading",
+      "Parameters": {
+        "filePath.$": "$.localFilePath",
+        "deleteAfterDownload": true
+      },
+      "ResultPath": "$.downloadUrl",
+      "Next": "Immediate"
+    },
+    "Immediate": {
+      "Type": "Pass",
+      "Result": {
+        "immediateDownload": true
+      },
+      "End": true
     }
   },
   "restrictions": [

--- a/lib/components/services/localfilestorage/index.js
+++ b/lib/components/services/localfilestorage/index.js
@@ -4,11 +4,14 @@ const fs = require('fs')
 const fsp = require('fs').promises
 
 class LocalFilestorage {
-  boot (options) {
+  async boot (options) {
     this.rootPath_ = configuredRootPath(options)
 
     const cloudstorage = cloudstorageService(options)
     cloudstorage.registerProvider(this)
+
+    const { temp } = options.bootedServices
+    this.downloadDir = await temp.makeTempDir('download')
   } // boot
 
   get rootPath () { return this.rootPath_ }
@@ -27,17 +30,20 @@ class LocalFilestorage {
     const rootedPath = this.resolvePath(folderPath)
     if (!rootedPath) return []
 
+    const resolvedFolderPath = rootedPath.substring(this.rootPath_.length)
     try {
       const contents = (await fsp.readdir(rootedPath, { withFileTypes: true }))
         .filter(content => content.isFile() || content.isDirectory())
         .map(content => {
           return {
             Name: content.name,
+            Path: path.join(resolvedFolderPath, content.name),
             launches: [{
               stateMachineName: 'tymly_downloadFromLocalFileStorage_1_0',
               title: 'Download',
               input: {
-                name: content.name
+                localFolderPath: this.downloadDir,
+                remoteFilePath: path.join(resolvedFolderPath, content.name)
               }
             }]
           }

--- a/lib/components/services/localfilestorage/index.js
+++ b/lib/components/services/localfilestorage/index.js
@@ -31,7 +31,16 @@ class LocalFilestorage {
       const contents = (await fsp.readdir(rootedPath, { withFileTypes: true }))
         .filter(content => content.isFile() || content.isDirectory())
         .map(content => {
-          return { Name: content.name }
+          return {
+            Name: content.name,
+            launches: [{
+              stateMachineName: 'tymly_downloadFromLocalFileStorage_1_0',
+              title: 'Download',
+              input: {
+                name: content.name
+              }
+            }]
+          }
         })
 
       return contents

--- a/lib/components/services/localfilestorage/index.js
+++ b/lib/components/services/localfilestorage/index.js
@@ -18,6 +18,9 @@ class LocalFilestorage {
     if (!rootedPath) throw new Error(`Bad folder path - ${folderPath}`)
 
     await fsp.mkdir(rootedPath, { recursive: true })
+    return {
+      folderPath: rootedPath.substring(this.rootPath_.length)
+    }
   } // ensureFolderPath
 
   async listFolderContentsFromPath (folderPath) {

--- a/lib/components/services/localfilestorage/index.js
+++ b/lib/components/services/localfilestorage/index.js
@@ -41,11 +41,12 @@ class LocalFilestorage {
     }
   } // listFolderContentsFromPath
 
-  async copyFileToRemotePath (localFilePath, remoteFolderPath) {
+  async copyFileToRemotePath (localFilePath, remoteFolderPath, remoteFileName = null) {
     const localFile = path.resolve(localFilePath)
     const rootedPath = this.resolvePath(remoteFolderPath)
 
-    const rootedFileName = path.join(rootedPath, path.basename(localFile))
+    const fileName = remoteFileName || path.basename(localFile)
+    const rootedFileName = path.join(rootedPath, fileName)
 
     await fsp.copyFile(localFile, rootedFileName)
 

--- a/test/boot-service-test.js
+++ b/test/boot-service-test.js
@@ -3,6 +3,7 @@
 const chai = require('chai')
 chai.use(require('dirty-chai'))
 chai.use(require('chai-string'))
+chai.use(require('chai-as-promised'))
 const expect = chai.expect
 
 const path = require('path')
@@ -12,9 +13,6 @@ const LocalStorageService = require('../lib/components/services/localfilestorage
 describe('Boot localstorage service', () => {
   let localstorage
   let options
-  const onBoot = () => {
-    localstorage.boot(options)
-  }
 
   const basePath = path.join(__dirname, 'fixture')
 
@@ -43,32 +41,32 @@ describe('Boot localstorage service', () => {
   })
 
   describe('good boots', () => {
-    it('picks up filesystem root directory from config', () => {
-      localstorage.boot(options)
+    it('picks up filesystem root directory from config', async () => {
+      await localstorage.boot(options)
       expect(localstorage.rootPath).to.endWith('config')
     })
 
-    it('picks up filesystem root directory from environment', () => {
+    it('picks up filesystem root directory from environment', async () => {
       delete options.config.localstorage
       process.env.TYMLY_LOCALSTORAGE_ROOTPATH = path.join(basePath, 'env')
 
-      localstorage.boot(options)
+      await localstorage.boot(options)
       expect(localstorage.rootPath).to.endWith('env')
     })
 
-    it('prefer config to environment variable', () => {
+    it('prefer config to environment variable', async () => {
       process.env.TYMLY_LOCALSTORAGE_ROOTPATH = '/from/env'
 
-      localstorage.boot(options)
+      await localstorage.boot(options)
       expect(localstorage.rootPath).to.endWith('config')
     })
 
-    it('localstorage registers with cloudstorage on boot', () => {
+    it('localstorage registers with cloudstorage on boot', async () => {
       let registered = false
       options.bootedServices.cloudstorage.registerProvider =
         provider => { registered = (provider === localstorage) }
 
-      localstorage.boot(options)
+      await localstorage.boot(options)
 
       expect(registered).to.be.true()
     })
@@ -78,19 +76,19 @@ describe('Boot localstorage service', () => {
     it('loudly fail if path config is missing', () => {
       delete options.config.localstorage
 
-      expect(onBoot).to.throw(/could not configure/i)
+      return expect(localstorage.boot(options)).to.eventually.be.rejectedWith(/could not configure/i)
     })
 
     it('fail if configure path is not absolute', () => {
       options.config.localstorage.rootPath = 'relative/path'
 
-      expect(onBoot).to.throw(/must be absolute/i)
+      expect(localstorage.boot(options)).to.eventually.be.rejectedWith(/must be absolute/i)
     })
 
     it('fail if configure path does not exist', () => {
       options.config.localstorage.rootPath = '/a/path/to/nowhere'
 
-      expect(onBoot).to.throw(/not exist/i)
+      expect(localstorage.boot(options)).to.eventually.be.rejectedWith(/not exist/i)
     })
 
     it("don't register if config is missing", () => {
@@ -100,20 +98,20 @@ describe('Boot localstorage service', () => {
       options.bootedServices.cloudstorage.registerProvider =
         provider => { registered = (provider === localstorage) }
 
-      expect(onBoot).to.throw(/could not configure/i)
+      expect(localstorage.boot(options)).to.eventually.be.rejectedWith(/could not configure/i)
       expect(registered).to.be.false()
     })
 
     it('loudly fail if cloudstorage is not available', () => {
       delete options.bootedServices.cloudstorage
 
-      expect(onBoot).to.throw(/can't find cloudstorage/i)
+      expect(localstorage.boot(options)).to.eventually.be.rejectedWith(/can't find cloudstorage/i)
     })
 
     it("loudly fail if cloudstorage isn't right", () => {
       delete options.bootedServices.cloudstorage.registerProvider
 
-      expect(onBoot).to.throw(/doesn't have registerProvider/i)
+      expect(localstorage.boot(options)).to.eventually.be.rejectedWith(/doesn't have registerProvider/i)
     })
   })
 })

--- a/test/boot-service-test.js
+++ b/test/boot-service-test.js
@@ -25,6 +25,9 @@ describe('Boot localstorage service', () => {
       bootedServices: {
         cloudstorage: {
           registerProvider: () => { }
+        },
+        temp: {
+          makeTempDir: () => { }
         }
       },
       config: {

--- a/test/method-copyFileToLocalPath.js
+++ b/test/method-copyFileToLocalPath.js
@@ -11,7 +11,7 @@ const fs = require('fs')
 
 const LocalStorageService = require('../lib/components/services/localfilestorage').serviceClass
 
-describe('copyFileToRemotePath', () => {
+describe('copyFileToLocalPath', () => {
   let localstorage
 
   const rootPath = path.join(__dirname, 'fixture', 'methods', 'copy-from')

--- a/test/method-copyFileToRemotePath.js
+++ b/test/method-copyFileToRemotePath.js
@@ -32,6 +32,7 @@ describe('copyFileToRemotePath', () => {
   }
 
   const fileName = 'hello.txt'
+  const renamedFileName = 'world.txt'
   const localPath = path.join(__dirname, 'fixture', 'local', fileName)
   const remotePath = path.join('to-write')
 
@@ -60,14 +61,15 @@ describe('copyFileToRemotePath', () => {
     })
 
     it('copy file to remote folder, giving filename', async () => {
-      const remoteFile = await localstorage.copyFileToRemotePath(localPath, path.join(remotePath, 'renamed-file'))
-      expect(remoteFile).to.equal(path.join('/', 'to-write', 'renamed-file'))
+      const remoteFile = await localstorage.copyFileToRemotePath(localPath, remotePath, renamedFileName)
+      expect(remoteFile).to.equal(path.join('/', 'to-write', renamedFileName))
     })
 
     it('target folder lists the file', async () => {
       const contents = await localstorage.listFolderContentsFromPath(remotePath)
-      expect(contents).to.have.length(1)
+      expect(contents).to.have.length(2)
       expect(contents).to.deep.include({ Name: fileName })
+      expect(contents).to.deep.include({ Name: renamedFileName })
     })
   })
 
@@ -80,7 +82,7 @@ describe('copyFileToRemotePath', () => {
 
     it('remote path does not exist', () => {
       return expect(
-        localstorage.copyFileToRemotePath(localPath, 'bad-path')
+        localstorage.copyFileToRemotePath(localPath, 'badpath')
       ).to.eventually.be.rejectedWith(Error)
     })
 

--- a/test/method-copyFileToRemotePath.js
+++ b/test/method-copyFileToRemotePath.js
@@ -54,9 +54,14 @@ describe('copyFileToRemotePath', () => {
       expect(contents).to.have.length(0)
     })
 
-    it('copy file to remote location', async () => {
+    it('copy file to remote folder', async () => {
       const remoteFile = await localstorage.copyFileToRemotePath(localPath, remotePath)
       expect(remoteFile).to.equal(path.join('/', 'to-write', fileName))
+    })
+
+    it('copy file to remote folder, giving filename', async () => {
+      const remoteFile = await localstorage.copyFileToRemotePath(localPath, path.join(remotePath, 'renamed-file'))
+      expect(remoteFile).to.equal(path.join('/', 'to-write', 'renamed-file'))
     })
 
     it('target folder lists the file', async () => {

--- a/test/method-copyFileToRemotePath.js
+++ b/test/method-copyFileToRemotePath.js
@@ -20,8 +20,10 @@ describe('copyFileToRemotePath', () => {
   const options = {
     bootedServices: {
       cloudstorage: {
-        registerProvider: () => {
-        }
+        registerProvider: () => { }
+      },
+      temp: {
+        makeTempDir: () => { }
       }
     },
     config: {
@@ -68,8 +70,9 @@ describe('copyFileToRemotePath', () => {
     it('target folder lists the file', async () => {
       const contents = await localstorage.listFolderContentsFromPath(remotePath)
       expect(contents).to.have.length(2)
-      expect(contents).to.deep.include({ Name: fileName })
-      expect(contents).to.deep.include({ Name: renamedFileName })
+      const names = contents.map(c => c.Name)
+      expect(names).to.include(fileName)
+      expect(names).to.include(renamedFileName)
     })
   })
 

--- a/test/method-listFolderContentsFromPath.js
+++ b/test/method-listFolderContentsFromPath.js
@@ -20,6 +20,9 @@ describe('listFolderContentsFromPath', () => {
     bootedServices: {
       cloudstorage: {
         registerProvider: () => { }
+      },
+      temp: {
+        makeTempDir: () => { }
       }
     },
     config: {
@@ -54,9 +57,9 @@ describe('listFolderContentsFromPath', () => {
     it('folder with files and sub-folders', async () => {
       const list = await localstorage.listFolderContentsFromPath('to-read')
       expect(list).to.have.length(5)
-
-      expect(list).to.deep.include({ Name: 'empty' })
-      expect(list).to.deep.include({ Name: 'file-one.txt' })
+      const names = list.map(c => c.Name)
+      expect(names).to.include('empty')
+      expect(names).to.include('file-one.txt')
     })
   })
 


### PR DESCRIPTION
Extend to support filedownloading. 

listFolderContents includes a launches property which can be dropped straight into a cardscript table. Download blueprint does the work of copying file locally and passing it off to fastify plugin.

Relies on https://github.com/wmfs/tymly-cloudstorage-plugin/pull/2