### PR TITLE
fix: Include root path in boot failure messages

### DIFF
--- a/lib/components/services/localfilestorage/index.js
+++ b/lib/components/services/localfilestorage/index.js
@@ -105,7 +105,7 @@ function configuredRootPath (options) {
   const rootPath = fromConfig || fromEnv
   if (!rootPath) bootOops(`Could not configure root path from ${configKey} or TYMLY_LOCALSTORAGE_ROOTPATH.`)
   if (!path.isAbsolute(rootPath)) bootOops('Configured root path is relative. It must be absolute.')
-  if (!fs.existsSync(rootPath)) bootOops('Configured root path does not exist.')
+  if (!fs.existsSync(rootPath)) bootOops(`Configured root path does not exist - ${rootPath}`)
 
   checkAccess(rootPath, fs.constants.R_OK, 'readable')
   checkAccess(rootPath, fs.constants.W_OK, 'writable')
@@ -117,7 +117,7 @@ function checkAccess (rootPath, flag, actionName) {
   try {
     fs.accessSync(rootPath, flag)
   } catch (e) {
-    bootOops(`Configured root path exists but is not ${actionName}.`)
+    bootOops(`Configured root path exists but is not ${actionName} - ${rootPath}`)
   }
 } // checkAccess
 


### PR DESCRIPTION
It's helpful to know which directory you're talking about :)